### PR TITLE
chore: add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ "main" ]   # Deploy when you push to main
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the main branch
+      - name: Checkout source
+        uses: actions/checkout@v3
+
+      # (Optional) If you need Node.js to build
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      # Install & build (edit if your build is different)
+      - name: Build site
+        run: |
+          npm install
+          npm run build
+
+      # Deploy to gh-pages branch
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./dist   # change to ./build if that’s your output folder


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to deploy to gh-pages on pushes to main

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b88cb8ef2c832ca43d14469a69e6a6