### PR TITLE
Fix GitHub Pages workflow for legal map

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,22 +18,10 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v3
 
-      # (Optional) If you need Node.js to build
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
-
-      # Install & build (edit if your build is different)
-      - name: Build site
-        run: |
-          npm install
-          npm run build
-
-      # Deploy to gh-pages branch
+      # Deploy the legal-map directory to gh-pages
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
-          publish_dir: ./dist   # change to ./build if that’s your output folder
+          publish_dir: ./legal-map


### PR DESCRIPTION
## Summary
- simplify GitHub Pages deployment workflow
- deploy `legal-map` directory directly without npm build step

## Testing
- `npm --prefix legal-map test`


------
https://chatgpt.com/codex/tasks/task_e_68b88e90ff50832cb767fc12c7d93998