### PR TITLE
Track item type for seen IDs

### DIFF
--- a/app/loops/poll_reddit.py
+++ b/app/loops/poll_reddit.py
@@ -94,7 +94,7 @@ def handle_new_item(item):
                                 f"⚠️ Failed to send welcome confirmation for {target_user}: {e}"
                             )
                         break
-        add_seen_id(item.id)
+        add_seen_id(item)
         return
     
     # 👇 ensure user row in Supabase
@@ -139,12 +139,12 @@ def handle_new_item(item):
 
     if author_name.lower() == bot_username:
         print(f"🤖 skipping queue for bot's own post/comment {item.id}")
-        add_seen_id(item.id)
+        add_seen_id(item)
         return
 
     # Fixed flair users bypass further checks - auto approve
     if author_name.lower() in FIXED_FLAIRS:
-        add_seen_id(item.id)
+        add_seen_id(item)
         item.mod.approve()
         old_k, new_k, flair, total_delta, extras = apply_approval_awards(
             item, is_manual=False
@@ -168,10 +168,10 @@ def handle_new_item(item):
 
     if already_moderated(item):
         print(f"⏩ Skipping {item.id} (already moderated)")
-        add_seen_id(item.id)
+        add_seen_id(item)
         return
 
-    add_seen_id(item.id)
+    add_seen_id(item)
 
     res = supabase.table("user_karma").select("*").ilike("username", author_name).execute()
     karma = int(res.data[0]["karma"]) if res.data else 0

--- a/app/persistence/pending_restore.py
+++ b/app/persistence/pending_restore.py
@@ -46,7 +46,7 @@ def restore_pending_reviews():
                 )
                 delete_pending_review(row["msg_id"])
                 try:
-                    add_seen_id(item.id)
+                    add_seen_id(item)
                 except Exception:
                     pass
                 continue

--- a/app/persistence/seen_ids.py
+++ b/app/persistence/seen_ids.py
@@ -17,9 +17,10 @@ def load_seen_ids() -> set[str]:
         return set()
 
 
-def save_seen_id(item_id: str) -> None:
-    """Persist a Reddit item ID to Supabase."""
+def save_seen_id(item_id: str, kind: str) -> None:
+    """Persist a Reddit item ID and its type to Supabase."""
     try:
-        supabase.table(_TABLE).upsert({"id": item_id}).execute()
+        supabase.table(_TABLE).upsert({"id": item_id, "kind": kind}).execute()
     except Exception as e:
         print(f"⚠️ Failed to save seen id {item_id}: {e}")
+


### PR DESCRIPTION
## Summary
- Upsert item `id` and `kind` in Supabase seen ID persistence
- Detect comment vs post in `add_seen_id` and record type
- Pass whole PRAW item to `add_seen_id` from polling and restore flows

## Testing
- `python -m py_compile app/persistence/seen_ids.py app/models/state.py app/loops/poll_reddit.py app/persistence/pending_restore.py`
- `pytest -q`
- `python - <<'PY'
from app.persistence.seen_ids import save_seen_id
try:
    save_seen_id("test123", "post")
    print("insert attempted")
except Exception as e:
    print("error", e)
PY` *(fails: `supabase_url is required`)*

------
https://chatgpt.com/codex/tasks/task_e_68baec3b6db4832cae608d353a6e6209