### PR TITLE
fix: ensure profile avatar renders as circle

### DIFF
--- a/legal-map/profile.css
+++ b/legal-map/profile.css
@@ -1538,10 +1538,12 @@ a.text-white:focus {
 .card-profile-image img {
   position: absolute;
   left: 50%;
-  max-width: 180px;
+  width: 180px;
+  height: 180px;
+  object-fit: cover;
   transition: all .15s ease;
   transform: translate(-50%, -30%);
-  border-radius: .375rem;
+  border-radius: 50%;
 }
 
 .card-profile-image img:hover {


### PR DESCRIPTION
## Summary
- keep profile avatars perfectly round by forcing equal width/height and cover fit

## Testing
- `npm test` (fails: package.json missing)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc9008b944832ca7691fbafd99fbdc