### PR TITLE
fix: center avatar and keep position while editing

### DIFF
--- a/legal-map/components/Profile.jsx
+++ b/legal-map/components/Profile.jsx
@@ -299,30 +299,25 @@ function Profile() {
               <div className="row justify-content-center">
                 <div className="col-lg-3 order-lg-2">
                   <div className="card-profile-image">
-                    {editing ? (
-                      <label htmlFor="avatar-upload" className="image-edit">
-                        <img
-                          src={avatarUrl || DEFAULT_AVATAR}
-                          className="rounded-circle"
-                          onError={(e) => {
-                            e.target.onerror = null;
-                            e.target.src = DEFAULT_AVATAR;
-                          }}
-                        />
-                        <span className="edit-overlay">
-                          <i className="fa-solid fa-plus-circle"></i>
-                        </span>
-                      </label>
-                    ) : (
+                    <label
+                      htmlFor="avatar-upload"
+                      className="image-edit"
+                      style={{ cursor: editing ? 'pointer' : 'default' }}
+                    >
                       <img
                         src={avatarUrl || DEFAULT_AVATAR}
                         className="rounded-circle"
                         onError={(e) => {
-                            e.target.onerror = null;
-                            e.target.src = DEFAULT_AVATAR;
-                          }}
+                          e.target.onerror = null;
+                          e.target.src = DEFAULT_AVATAR;
+                        }}
                       />
+                      {editing && (
+                        <span className="edit-overlay">
+                          <i className="fa-solid fa-plus-circle"></i>
+                        </span>
                       )}
+                    </label>
                     {editing && (
                       <input
                         type="file"

--- a/legal-map/profile.css
+++ b/legal-map/profile.css
@@ -1533,14 +1533,19 @@ a.text-white:focus {
 
 .card-profile-image {
   position: relative;
+  width: 180px;
+  height: 180px;
+  margin: 0 auto;
 }
 
 .card-profile-image img {
   position: absolute;
   left: 50%;
+  top: 0;
   width: 180px;
   height: 180px;
   object-fit: cover;
+  object-position: center;
   transition: all .15s ease;
   transform: translate(-50%, -30%);
   border-radius: 50%;
@@ -2126,6 +2131,9 @@ p {
 .image-edit {
   position: relative;
   cursor: pointer;
+  display: block;
+  width: 100%;
+  height: 100%;
 }
 
 .image-edit .edit-overlay {


### PR DESCRIPTION
## Summary
- ensure the profile avatar keeps its place when toggling settings by always wrapping the image in a label
- center-crop the avatar with fixed dimensions so it renders as a circle

## Testing
- `cd legal-map && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc92db84cc832cb778b50b80eb88b8