### PR TITLE
Hide update profile button until editing mode

### DIFF
--- a/legal-map/components/Profile.jsx
+++ b/legal-map/components/Profile.jsx
@@ -216,6 +216,7 @@ function Profile() {
       setPostalCode(data.user.user_metadata?.postal_code || '');
       setAboutMe(data.user.user_metadata?.about_me || '');
       setBirthdate(data.user.user_metadata?.birthdate || '');
+      setEditing(false);
     }
   };
 
@@ -286,7 +287,7 @@ function Profile() {
                 onClick={() => setEditing(!editing)}
                 type="button"
               >
-                {editing ? 'Done' : 'Settings'}
+                Settings
               </button>
             </div>
           </div>
@@ -606,15 +607,17 @@ function Profile() {
                       />
                     </div>
                   </div>
-                  <div className="pl-lg-4">
-                    <button
-                      type="submit"
-                      className="btn btn-primary"
-                      disabled={loading}
-                    >
-                      {loading ? 'Updating...' : 'Update Profile'}
-                    </button>
-                  </div>
+                  {editing && (
+                    <div className="pl-lg-4">
+                      <button
+                        type="submit"
+                        className="btn btn-primary"
+                        disabled={loading}
+                      >
+                        {loading ? 'Updating...' : 'Update Profile'}
+                      </button>
+                    </div>
+                  )}
                   </fieldset>
                 </form>
               </div>


### PR DESCRIPTION
## Summary
- Always label the profile action button as "Settings" instead of toggling to "Done"
- Hide the "Update Profile" submit button until edit mode is active
- Exit edit mode automatically after saving changes

## Testing
- `npm test --prefix legal-map`

------
https://chatgpt.com/codex/tasks/task_e_68bc9a3b5ba0832c90027312e76f1568