### PR TITLE
Hide settings button while editing profile and center avatar overlay

### DIFF
--- a/legal-map/components/Profile.jsx
+++ b/legal-map/components/Profile.jsx
@@ -282,13 +282,15 @@ function Profile() {
                 This is your profile page. You can see the progress you've made
                 with your work and manage your projects or assigned tasks
               </p>
-              <button
-                className="btn btn-info"
-                onClick={() => setEditing(!editing)}
-                type="button"
-              >
-                Settings
-              </button>
+              {!editing && (
+                <button
+                  className="btn btn-info"
+                  onClick={() => setEditing(true)}
+                  type="button"
+                >
+                  Settings
+                </button>
+              )}
             </div>
           </div>
         </div>

--- a/legal-map/profile.css
+++ b/legal-map/profile.css
@@ -2146,6 +2146,12 @@ p {
   justify-content: center;
   color: #fff;
   font-size: 2rem;
+  transform: translateY(-30%);
+  transition: transform .15s ease;
+}
+
+.image-edit:hover .edit-overlay {
+  transform: translateY(-33%);
 }
 
 .header .edit-overlay {


### PR DESCRIPTION
## Summary
- Hide profile Settings button after it is clicked so it doesn't remain visible while editing
- Align the avatar upload plus icon centrally over the profile picture

## Testing
- `npm test --prefix legal-map`


------
https://chatgpt.com/codex/tasks/task_e_68bc9bfdcd60832cb0a7a14a909bc19b