### PR TITLE
Track marker creators and show count in profile

### DIFF
--- a/legal-map/app.jsx
+++ b/legal-map/app.jsx
@@ -454,7 +454,14 @@ function App() {
       if (sb) {
         const { data: inserted, error } = await sb
           .from('map_markers')
-          .insert({ name, country, category, coordinates: coords, description })
+          .insert({
+            name,
+            country,
+            category,
+            coordinates: coords,
+            description,
+            user_id: userId
+          })
           .select();
         if (error) {
           console.error('Supabase insert error', error);

--- a/legal-map/components/Profile.jsx
+++ b/legal-map/components/Profile.jsx
@@ -16,6 +16,7 @@ function Profile() {
   const [avatarUrl, setAvatarUrl] = React.useState('');
   const [coverPath, setCoverPath] = React.useState('');
   const [coverUrl, setCoverUrl] = React.useState('');
+  const [markersCount, setMarkersCount] = React.useState(0);
   // Use reliable placeholder images for avatars and cover photos. The previous
   // links pointed to Argon Dashboard assets that occasionally return 4xx/5xx
   // responses, leaving a broken image icon in the UI. By switching to static
@@ -45,6 +46,15 @@ function Profile() {
       setAboutMe(user?.user_metadata?.about_me || '');
       setBirthdate(user?.user_metadata?.birthdate || '');
       if (user) {
+        const { count: markerCount, error: markerError } = await supabaseClient
+          .from('map_markers')
+          .select('id', { count: 'exact', head: true })
+          .eq('user_id', user.id);
+        if (markerError) {
+          console.error(markerError);
+        }
+        setMarkersCount(markerCount || 0);
+
         const { data: profile, error: profileError } = await supabaseClient
           .from('profiles')
           .select('avatar_url, cover_url')
@@ -348,7 +358,7 @@ function Profile() {
                     <div className="col">
                       <div className="card-profile-stats d-flex justify-content-center mt-md-5">
                         <div>
-                          <span className="heading">{user.user_metadata?.markers_created || 0}</span>
+                          <span className="heading">{markersCount}</span>
                           <span className="description">Markers</span>
                         </div>
                         <div>


### PR DESCRIPTION
## Summary
- record `user_id` when inserting new map markers
- display per-user marker totals on the profile page

## Testing
- `pytest`
- `cd legal-map && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bca2dbf564832c9314abc77fc18b54