### PR TITLE
Ensure map marker action requests reach Discord

### DIFF
--- a/app/loops/loop_marker_actions.py
+++ b/app/loops/loop_marker_actions.py
@@ -10,8 +10,11 @@ from app.config import DISCORD_MAP_CHANNEL_ID
 
 async def _send_action(row):
     channel = bot.get_channel(DISCORD_MAP_CHANNEL_ID)
-    if not channel:
-        return None
+    if channel is None:
+        try:
+            channel = await bot.fetch_channel(DISCORD_MAP_CHANNEL_ID)
+        except Exception:
+            return None
     action = row.get("action")
     user = row.get("username", "unknown")
     name = row.get("name", "")


### PR DESCRIPTION
## Summary
- Fallback to fetching the Discord map channel when sending marker edit/delete approval requests

## Testing
- `python -m py_compile app/loops/loop_marker_actions.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcb3bb4820832c8752cdfac036c494