### PR TITLE
Align rating stars to the right on mobile

### DIFF
--- a/legal-map/marker.css
+++ b/legal-map/marker.css
@@ -153,6 +153,13 @@
     gap: 0.5rem;
 }
 
+@media (max-width: 768px) {
+    .rating-field {
+        width: 100%;
+        justify-content: space-between;
+    }
+}
+
 .rating {
     display: inline-flex;
     flex-direction: row-reverse;


### PR DESCRIPTION
## Summary
- Align rating star widgets to the right side on mobile devices while keeping labels on the left

## Testing
- `cd legal-map && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdf99bcc98832c9ded5f9fd6cb1b2d