### PR TITLE
Add fallback channel fetch for review cards

### DIFF
--- a/app/moderation/cards_send.py
+++ b/app/moderation/cards_send.py
@@ -45,6 +45,12 @@ async def send_discord_approval(item, lang_label=None, note=None, night_guard_pi
     """Send item to Discord for manual review; supports Night Guard ping + SLA priority + ETA."""
     channel = bot.get_channel(DISCORD_CHANNEL_ID)
     if not channel:
+        try:
+            channel = await bot.fetch_channel(DISCORD_CHANNEL_ID)
+        except Exception as e:
+            print(f"⚠️ Discord channel fetch failed: {e}")
+            return
+    if not channel:
         print("⚠️ Discord channel not found")
         return
 


### PR DESCRIPTION
## Summary
- fall back to fetching the Discord review channel when it is not yet cached before sending approval cards

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68c94fb4be80832c88c6f9a86b78b782