### PR TITLE
Handle Discord reminder rate limits gracefully

### DIFF
--- a/app/loops/loop_reminders.py
+++ b/app/loops/loop_reminders.py
@@ -1,13 +1,12 @@
-"""
-Loop for scheduled Discord reminders.
-"""
+"""Loop for scheduled Discord reminders."""
 
-import time
 import asyncio
+import time
 from datetime import datetime
 
+import discord
+
 from app.clients.discord_bot import bot
-from app.clients.supabase import supabase
 from app.config import DISCORD_POSTING_CHANNEL_ID
 from app.models.state import pending_reminders
 from app.utils.tz import current_tz
@@ -15,33 +14,84 @@ from app.utils.tz import current_tz
 
 async def cleanup_old_reminders():
     """Delete previous reminder cards from the posting channel."""
+
     channel = bot.get_channel(DISCORD_POSTING_CHANNEL_ID)
     if not channel:
         return
     try:
         await channel.purge(limit=100, check=lambda m: m.author == bot.user)
         print("🧹 Cleaned old reminder cards")
-    except Exception as e:
-        print(f"⚠️ Failed to cleanup reminders: {e}")
+    except Exception as error:  # pragma: no cover - defensive logging
+        print(f"⚠️ Failed to cleanup reminders: {error}")
+
+
+def _retry_after_seconds(error: discord.HTTPException, fallback: float) -> float:
+    """Extract a retry delay from the exception if available."""
+
+    retry_after = getattr(error, "retry_after", None)
+    if retry_after is not None:
+        try:
+            return float(retry_after)
+        except (TypeError, ValueError):
+            pass
+
+    response = getattr(error, "response", None)
+    headers = getattr(response, "headers", None)
+    if headers and isinstance(headers, dict):
+        retry_after_header = headers.get("Retry-After") or headers.get("retry-after")
+        if retry_after_header:
+            try:
+                return float(retry_after_header)
+            except (TypeError, ValueError):
+                pass
+
+    return fallback
 
 
 def _post_card(series: str, content: str) -> None:
     """Send a reminder card and register it for approval."""
+
     channel = bot.get_channel(DISCORD_POSTING_CHANNEL_ID)
     if not channel:
         print("⚠️ Posting channel not found")
         return
-    try:
-        msg = asyncio.run_coroutine_threadsafe(channel.send(content), bot.loop).result()
-        asyncio.run_coroutine_threadsafe(msg.add_reaction("✅"), bot.loop)
-        asyncio.run_coroutine_threadsafe(msg.add_reaction("❌"), bot.loop)
-        pending_reminders[msg.id] = {"series": series, "created_ts": time.time()}
-    except Exception as e:
-        print(f"⚠️ Failed to send reminder card: {e}")
+
+    max_attempts = 3
+    backoff = 10.0
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            msg = asyncio.run_coroutine_threadsafe(
+                channel.send(content), bot.loop
+            ).result()
+            asyncio.run_coroutine_threadsafe(msg.add_reaction("✅"), bot.loop)
+            asyncio.run_coroutine_threadsafe(msg.add_reaction("❌"), bot.loop)
+            pending_reminders[msg.id] = {
+                "series": series,
+                "created_ts": time.time(),
+            }
+            return
+        except discord.HTTPException as error:
+            if error.status == 429 and attempt < max_attempts:
+                delay = _retry_after_seconds(error, backoff)
+                print(
+                    "⚠️ Rate limited sending reminder card. "
+                    f"Retrying in {delay:.1f}s (attempt {attempt}/{max_attempts})."
+                )
+                time.sleep(delay)
+                backoff *= 2
+                continue
+
+            print(f"⚠️ Failed to send reminder card: {error}")
+            return
+        except Exception as error:  # pragma: no cover - defensive logging
+            print(f"⚠️ Failed to send reminder card: {error}")
+            return
 
 
 def reminder_loop():
     """Main loop that posts scheduled reminders."""
+
     print("🕒 Reminder loop started...")
     while True:
         try:
@@ -55,6 +105,6 @@ def reminder_loop():
             elif now.hour == 14 and now.minute == 0:
                 _post_card("afternoon", "✍️ Reminder: own post")
                 time.sleep(60)
-        except Exception as e:
-            print(f"⚠️ Reminder loop error: {e}")
+        except Exception as error:  # pragma: no cover - defensive logging
+            print(f"⚠️ Reminder loop error: {error}")
         time.sleep(30)


### PR DESCRIPTION
## Summary
- add retry handling for Discord reminder posting failures caused by rate limiting
- log clearer messages and back off before retrying when a reminder send is rate limited

## Testing
- python -m compileall app/loops/loop_reminders.py

------
https://chatgpt.com/codex/tasks/task_e_68d6a6e83124832c8c39b6e3ae1169d9