### PR TITLE
Avoid fetching Discord messages before deletion

### DIFF
--- a/app/loops/loop_sla.py
+++ b/app/loops/loop_sla.py
@@ -18,7 +18,7 @@ async def _escalate_card(msg_id: int):
 
     try:
         channel = bot.get_channel(DISCORD_CHANNEL_ID)
-        old_msg = await channel.fetch_message(msg_id)
+        old_msg = channel.get_partial_message(msg_id)
         await old_msg.delete()
     except Exception:
         pass

--- a/app/loops/poll_reddit.py
+++ b/app/loops/poll_reddit.py
@@ -73,10 +73,10 @@ def handle_new_item(item):
                         and data.get("username", "").lower() == target_user.lower()
                     ):
                         try:
-                            msg = asyncio.run_coroutine_threadsafe(
-                                channel.fetch_message(msg_id), bot.loop
+                            msg = channel.get_partial_message(msg_id)
+                            asyncio.run_coroutine_threadsafe(
+                                msg.delete(), bot.loop
                             ).result()
-                            asyncio.run_coroutine_threadsafe(msg.delete(), bot.loop)
                         except Exception as e:
                             print(
                                 f"⚠️ Failed to delete reminder msg {msg_id} for {target_user}: {e}"

--- a/app/persistence/pending_restore.py
+++ b/app/persistence/pending_restore.py
@@ -19,7 +19,7 @@ async def _delete_discord_card(msg_id: int) -> None:
         channel = bot.get_channel(DISCORD_CHANNEL_ID)
         if not channel:
             return
-        msg = await channel.fetch_message(msg_id)
+        msg = channel.get_partial_message(msg_id)
         await msg.delete()
         print(f"🗑️ Deleted old Discord card {msg_id}")
     except Exception:


### PR DESCRIPTION
## Summary
- replace Discord message fetches with partial message deletes to avoid extra GET requests
- apply the change across SLA escalation, reminder cleanup, and pending review restoration helpers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6a87dab34832c81edb676b2c8a5fd